### PR TITLE
Bugfixes to price update, modifications based on API changes

### DIFF
--- a/MKMTool/CheckDisplayPrices.cs
+++ b/MKMTool/CheckDisplayPrices.cs
@@ -169,7 +169,7 @@ namespace MKMTool
 
                         var doc2 =
                             MKMInteract.RequestHelper.makeRequest(
-                                "https://www.mkmapi.eu/ws/v2.0/products/" + xn["idProduct"].InnerText, "GET");
+                                "https://api.cardmarket.com/ws/v2.0/products/" + xn["idProduct"].InnerText, "GET");
 
                         var fCardPrice =
                             (float)
@@ -191,7 +191,7 @@ namespace MKMTool
 
                         var doc2 =
                             MKMInteract.RequestHelper.makeRequest(
-                                "https://www.mkmapi.eu/ws/v2.0/products/" + xn["idProduct"].InnerText, "GET");
+                                "https://api.cardmarket.com/ws/v2.0/products/" + xn["idProduct"].InnerText, "GET");
 
                         var fCardPrice =
                             (float)
@@ -212,7 +212,7 @@ namespace MKMTool
 
                         var doc2 =
                             MKMInteract.RequestHelper.makeRequest(
-                                "https://www.mkmapi.eu/ws/v2.0/products/" + xn["idProduct"].InnerText, "GET");
+                                "https://api.cardmarket.com/ws/v2.0/products/" + xn["idProduct"].InnerText, "GET");
 
                         var fCardPrice =
                             (float)

--- a/MKMTool/CheckWantsView.Designer.cs
+++ b/MKMTool/CheckWantsView.Designer.cs
@@ -398,7 +398,6 @@
         private System.Windows.Forms.ComboBox editionBox;
         private System.Windows.Forms.Button checkEditionButton;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.GroupBox groupBox4;
         private System.Windows.Forms.CheckBox signedBox;

--- a/MKMTool/CheckWantsView.Designer.cs
+++ b/MKMTool/CheckWantsView.Designer.cs
@@ -38,11 +38,14 @@
             this.editionBox = new System.Windows.Forms.ComboBox();
             this.checkEditionButton = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.checkBestInter = new System.Windows.Forms.CheckBox();
             this.domnesticCheck = new System.Windows.Forms.CheckBox();
             this.maxPrice = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.checkTrend = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.textBoxUser = new System.Windows.Forms.TextBox();
+            this.checkBoxUser = new System.Windows.Forms.CheckBox();
             this.signedBox = new System.Windows.Forms.CheckBox();
             this.foilBox = new System.Windows.Forms.CheckBox();
             this.alteredBox = new System.Windows.Forms.CheckBox();
@@ -52,7 +55,6 @@
             this.langCombo = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.checkBestInter = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.groupBox4.SuspendLayout();
@@ -63,19 +65,17 @@
             this.wantListsBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.wantListsBox2.FormattingEnabled = true;
-            this.wantListsBox2.Location = new System.Drawing.Point(12, 283);
-            this.wantListsBox2.Margin = new System.Windows.Forms.Padding(6);
+            this.wantListsBox2.Location = new System.Drawing.Point(6, 147);
             this.wantListsBox2.Name = "wantListsBox2";
-            this.wantListsBox2.Size = new System.Drawing.Size(372, 33);
+            this.wantListsBox2.Size = new System.Drawing.Size(188, 21);
             this.wantListsBox2.TabIndex = 0;
             this.wantListsBox2.SelectedIndexChanged += new System.EventHandler(this.wantListsBox2_SelectedIndexChanged);
             // 
             // checkListButton
             // 
-            this.checkListButton.Location = new System.Drawing.Point(12, 335);
-            this.checkListButton.Margin = new System.Windows.Forms.Padding(6);
+            this.checkListButton.Location = new System.Drawing.Point(6, 174);
             this.checkListButton.Name = "checkListButton";
-            this.checkListButton.Size = new System.Drawing.Size(376, 98);
+            this.checkListButton.Size = new System.Drawing.Size(188, 51);
             this.checkListButton.TabIndex = 6;
             this.checkListButton.Text = "Check selected List";
             this.checkListButton.UseVisualStyleBackColor = true;
@@ -83,48 +83,43 @@
             // 
             // percentText
             // 
-            this.percentText.Location = new System.Drawing.Point(12, 37);
-            this.percentText.Margin = new System.Windows.Forms.Padding(6);
+            this.percentText.Location = new System.Drawing.Point(6, 19);
             this.percentText.Name = "percentText";
-            this.percentText.Size = new System.Drawing.Size(76, 31);
+            this.percentText.Size = new System.Drawing.Size(40, 20);
             this.percentText.TabIndex = 7;
             this.percentText.Text = "20";
             // 
             // labelPercent
             // 
             this.labelPercent.AutoSize = true;
-            this.labelPercent.Location = new System.Drawing.Point(104, 42);
-            this.labelPercent.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.labelPercent.Location = new System.Drawing.Point(52, 22);
             this.labelPercent.Name = "labelPercent";
-            this.labelPercent.Size = new System.Drawing.Size(159, 25);
+            this.labelPercent.Size = new System.Drawing.Size(78, 13);
             this.labelPercent.TabIndex = 8;
             this.labelPercent.Text = "% below others";
             // 
             // shipAddition
             // 
-            this.shipAddition.Location = new System.Drawing.Point(12, 87);
-            this.shipAddition.Margin = new System.Windows.Forms.Padding(6);
+            this.shipAddition.Location = new System.Drawing.Point(6, 45);
             this.shipAddition.Name = "shipAddition";
-            this.shipAddition.Size = new System.Drawing.Size(76, 31);
+            this.shipAddition.Size = new System.Drawing.Size(40, 20);
             this.shipAddition.TabIndex = 10;
             this.shipAddition.Text = "1";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(104, 92);
-            this.label2.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label2.Location = new System.Drawing.Point(52, 48);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(180, 25);
+            this.label2.Size = new System.Drawing.Size(89, 13);
             this.label2.TabIndex = 11;
             this.label2.Text = "Shipping Addition";
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(12, 335);
-            this.button1.Margin = new System.Windows.Forms.Padding(6);
+            this.button1.Location = new System.Drawing.Point(6, 174);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(380, 98);
+            this.button1.Size = new System.Drawing.Size(190, 51);
             this.button1.TabIndex = 13;
             this.button1.Text = "Empty Cart";
             this.button1.UseVisualStyleBackColor = true;
@@ -133,18 +128,16 @@
             // editionBox
             // 
             this.editionBox.FormattingEnabled = true;
-            this.editionBox.Location = new System.Drawing.Point(12, 283);
-            this.editionBox.Margin = new System.Windows.Forms.Padding(6);
+            this.editionBox.Location = new System.Drawing.Point(6, 151);
             this.editionBox.Name = "editionBox";
-            this.editionBox.Size = new System.Drawing.Size(372, 33);
+            this.editionBox.Size = new System.Drawing.Size(188, 21);
             this.editionBox.TabIndex = 27;
             // 
             // checkEditionButton
             // 
-            this.checkEditionButton.Location = new System.Drawing.Point(12, 335);
-            this.checkEditionButton.Margin = new System.Windows.Forms.Padding(6);
+            this.checkEditionButton.Location = new System.Drawing.Point(6, 174);
             this.checkEditionButton.Name = "checkEditionButton";
-            this.checkEditionButton.Size = new System.Drawing.Size(376, 98);
+            this.checkEditionButton.Size = new System.Drawing.Size(188, 51);
             this.checkEditionButton.TabIndex = 28;
             this.checkEditionButton.Text = "Check now";
             this.checkEditionButton.UseVisualStyleBackColor = true;
@@ -162,44 +155,51 @@
             this.groupBox1.Controls.Add(this.labelPercent);
             this.groupBox1.Controls.Add(this.shipAddition);
             this.groupBox1.Controls.Add(this.label2);
-            this.groupBox1.Location = new System.Drawing.Point(22, 23);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(6);
+            this.groupBox1.Location = new System.Drawing.Point(11, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(6);
-            this.groupBox1.Size = new System.Drawing.Size(404, 444);
+            this.groupBox1.Size = new System.Drawing.Size(202, 231);
             this.groupBox1.TabIndex = 29;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Price Parameter";
+            // 
+            // checkBestInter
+            // 
+            this.checkBestInter.AutoSize = true;
+            this.checkBestInter.Checked = true;
+            this.checkBestInter.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBestInter.Location = new System.Drawing.Point(6, 136);
+            this.checkBestInter.Name = "checkBestInter";
+            this.checkBestInter.Size = new System.Drawing.Size(165, 17);
+            this.checkBestInter.TabIndex = 16;
+            this.checkBestInter.Text = "check best price international";
+            this.checkBestInter.UseVisualStyleBackColor = true;
             // 
             // domnesticCheck
             // 
             this.domnesticCheck.AutoSize = true;
             this.domnesticCheck.Checked = true;
             this.domnesticCheck.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.domnesticCheck.Location = new System.Drawing.Point(12, 221);
-            this.domnesticCheck.Margin = new System.Windows.Forms.Padding(6);
+            this.domnesticCheck.Location = new System.Drawing.Point(6, 115);
             this.domnesticCheck.Name = "domnesticCheck";
-            this.domnesticCheck.Size = new System.Drawing.Size(283, 29);
+            this.domnesticCheck.Size = new System.Drawing.Size(151, 17);
             this.domnesticCheck.TabIndex = 15;
-            this.domnesticCheck.Text = "check german deals only";
+            this.domnesticCheck.Text = "check domestic deals only";
             this.domnesticCheck.UseVisualStyleBackColor = true;
             // 
             // maxPrice
             // 
-            this.maxPrice.Location = new System.Drawing.Point(12, 137);
-            this.maxPrice.Margin = new System.Windows.Forms.Padding(6);
+            this.maxPrice.Location = new System.Drawing.Point(6, 71);
             this.maxPrice.Name = "maxPrice";
-            this.maxPrice.Size = new System.Drawing.Size(76, 31);
+            this.maxPrice.Size = new System.Drawing.Size(40, 20);
             this.maxPrice.TabIndex = 13;
             this.maxPrice.Text = "10";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(104, 142);
-            this.label3.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label3.Location = new System.Drawing.Point(52, 74);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(197, 25);
+            this.label3.Size = new System.Drawing.Size(97, 13);
             this.label3.TabIndex = 14;
             this.label3.Text = "Max Price per Card";
             // 
@@ -208,16 +208,17 @@
             this.checkTrend.AutoSize = true;
             this.checkTrend.Checked = true;
             this.checkTrend.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkTrend.Location = new System.Drawing.Point(12, 180);
-            this.checkTrend.Margin = new System.Windows.Forms.Padding(6);
+            this.checkTrend.Location = new System.Drawing.Point(6, 94);
             this.checkTrend.Name = "checkTrend";
-            this.checkTrend.Size = new System.Drawing.Size(163, 29);
+            this.checkTrend.Size = new System.Drawing.Size(87, 17);
             this.checkTrend.TabIndex = 12;
             this.checkTrend.Text = "check Trend";
             this.checkTrend.UseVisualStyleBackColor = true;
             // 
             // groupBox3
             // 
+            this.groupBox3.Controls.Add(this.textBoxUser);
+            this.groupBox3.Controls.Add(this.checkBoxUser);
             this.groupBox3.Controls.Add(this.signedBox);
             this.groupBox3.Controls.Add(this.editionBox);
             this.groupBox3.Controls.Add(this.foilBox);
@@ -228,23 +229,40 @@
             this.groupBox3.Controls.Add(this.playsetBox);
             this.groupBox3.Controls.Add(this.langCombo);
             this.groupBox3.Controls.Add(this.label1);
-            this.groupBox3.Location = new System.Drawing.Point(438, 23);
-            this.groupBox3.Margin = new System.Windows.Forms.Padding(6);
+            this.groupBox3.Location = new System.Drawing.Point(219, 12);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Padding = new System.Windows.Forms.Padding(6);
-            this.groupBox3.Size = new System.Drawing.Size(400, 444);
+            this.groupBox3.Size = new System.Drawing.Size(200, 231);
             this.groupBox3.TabIndex = 31;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Bulk Check";
+            // 
+            // textBoxUser
+            // 
+            this.textBoxUser.Enabled = false;
+            this.textBoxUser.Location = new System.Drawing.Point(103, 127);
+            this.textBoxUser.Name = "textBoxUser";
+            this.textBoxUser.Size = new System.Drawing.Size(91, 20);
+            this.textBoxUser.TabIndex = 42;
+            // 
+            // checkBoxUser
+            // 
+            this.checkBoxUser.AutoSize = true;
+            this.checkBoxUser.Location = new System.Drawing.Point(6, 127);
+            this.checkBoxUser.Name = "checkBoxUser";
+            this.checkBoxUser.Size = new System.Drawing.Size(48, 17);
+            this.checkBoxUser.TabIndex = 41;
+            this.checkBoxUser.Text = "User";
+            this.checkBoxUser.UseVisualStyleBackColor = true;
+            this.checkBoxUser.CheckedChanged += new System.EventHandler(this.checkBoxUser_CheckedChanged);
             // 
             // signedBox
             // 
             this.signedBox.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.signedBox.AutoSize = true;
-            this.signedBox.Location = new System.Drawing.Point(12, 206);
-            this.signedBox.Margin = new System.Windows.Forms.Padding(4);
+            this.signedBox.Location = new System.Drawing.Point(6, 107);
+            this.signedBox.Margin = new System.Windows.Forms.Padding(2);
             this.signedBox.Name = "signedBox";
-            this.signedBox.Size = new System.Drawing.Size(111, 29);
+            this.signedBox.Size = new System.Drawing.Size(59, 17);
             this.signedBox.TabIndex = 40;
             this.signedBox.Text = "Signed";
             this.signedBox.UseVisualStyleBackColor = true;
@@ -253,10 +271,10 @@
             // 
             this.foilBox.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.foilBox.AutoSize = true;
-            this.foilBox.Location = new System.Drawing.Point(206, 165);
-            this.foilBox.Margin = new System.Windows.Forms.Padding(4);
+            this.foilBox.Location = new System.Drawing.Point(103, 86);
+            this.foilBox.Margin = new System.Windows.Forms.Padding(2);
             this.foilBox.Name = "foilBox";
-            this.foilBox.Size = new System.Drawing.Size(79, 29);
+            this.foilBox.Size = new System.Drawing.Size(42, 17);
             this.foilBox.TabIndex = 37;
             this.foilBox.Text = "Foil";
             this.foilBox.UseVisualStyleBackColor = true;
@@ -265,10 +283,10 @@
             // 
             this.alteredBox.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.alteredBox.AutoSize = true;
-            this.alteredBox.Location = new System.Drawing.Point(206, 206);
-            this.alteredBox.Margin = new System.Windows.Forms.Padding(4);
+            this.alteredBox.Location = new System.Drawing.Point(103, 107);
+            this.alteredBox.Margin = new System.Windows.Forms.Padding(2);
             this.alteredBox.Name = "alteredBox";
-            this.alteredBox.Size = new System.Drawing.Size(112, 29);
+            this.alteredBox.Size = new System.Drawing.Size(59, 17);
             this.alteredBox.TabIndex = 39;
             this.alteredBox.Text = "Altered";
             this.alteredBox.UseVisualStyleBackColor = true;
@@ -277,10 +295,10 @@
             // 
             this.conditionBox.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.conditionBox.AutoSize = true;
-            this.conditionBox.Location = new System.Drawing.Point(200, 92);
-            this.conditionBox.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.conditionBox.Location = new System.Drawing.Point(100, 48);
+            this.conditionBox.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.conditionBox.Name = "conditionBox";
-            this.conditionBox.Size = new System.Drawing.Size(195, 25);
+            this.conditionBox.Size = new System.Drawing.Size(95, 13);
             this.conditionBox.TabIndex = 34;
             this.conditionBox.Text = "Minimum Condition";
             // 
@@ -290,26 +308,26 @@
             this.conditionCombo.FormattingEnabled = true;
             this.conditionCombo.Items.AddRange(new object[] {
             "MT",
-            "NM ",
+            "NM",
             "EX",
             "GD",
             "LP",
             "PL",
             "PO"});
-            this.conditionCombo.Location = new System.Drawing.Point(12, 87);
-            this.conditionCombo.Margin = new System.Windows.Forms.Padding(4);
+            this.conditionCombo.Location = new System.Drawing.Point(6, 45);
+            this.conditionCombo.Margin = new System.Windows.Forms.Padding(2);
             this.conditionCombo.Name = "conditionCombo";
-            this.conditionCombo.Size = new System.Drawing.Size(176, 33);
+            this.conditionCombo.Size = new System.Drawing.Size(90, 21);
             this.conditionCombo.TabIndex = 33;
             // 
             // playsetBox
             // 
             this.playsetBox.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.playsetBox.AutoSize = true;
-            this.playsetBox.Location = new System.Drawing.Point(12, 165);
-            this.playsetBox.Margin = new System.Windows.Forms.Padding(4);
+            this.playsetBox.Location = new System.Drawing.Point(6, 86);
+            this.playsetBox.Margin = new System.Windows.Forms.Padding(2);
             this.playsetBox.Name = "playsetBox";
-            this.playsetBox.Size = new System.Drawing.Size(115, 29);
+            this.playsetBox.Size = new System.Drawing.Size(60, 17);
             this.playsetBox.TabIndex = 38;
             this.playsetBox.Text = "Playset";
             this.playsetBox.UseVisualStyleBackColor = true;
@@ -318,20 +336,20 @@
             // 
             this.langCombo.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.langCombo.FormattingEnabled = true;
-            this.langCombo.Location = new System.Drawing.Point(12, 35);
-            this.langCombo.Margin = new System.Windows.Forms.Padding(4);
+            this.langCombo.Location = new System.Drawing.Point(6, 18);
+            this.langCombo.Margin = new System.Windows.Forms.Padding(2);
             this.langCombo.Name = "langCombo";
-            this.langCombo.Size = new System.Drawing.Size(176, 33);
+            this.langCombo.Size = new System.Drawing.Size(90, 21);
             this.langCombo.TabIndex = 35;
             // 
             // label1
             // 
             this.label1.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(200, 42);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(100, 22);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(108, 25);
+            this.label1.Size = new System.Drawing.Size(55, 13);
             this.label1.TabIndex = 36;
             this.label1.Text = "Language";
             // 
@@ -339,39 +357,23 @@
             // 
             this.groupBox4.Controls.Add(this.checkListButton);
             this.groupBox4.Controls.Add(this.wantListsBox2);
-            this.groupBox4.Location = new System.Drawing.Point(850, 23);
-            this.groupBox4.Margin = new System.Windows.Forms.Padding(6);
+            this.groupBox4.Location = new System.Drawing.Point(425, 12);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Padding = new System.Windows.Forms.Padding(6);
-            this.groupBox4.Size = new System.Drawing.Size(400, 444);
+            this.groupBox4.Size = new System.Drawing.Size(200, 231);
             this.groupBox4.TabIndex = 32;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Check Wantslist";
             // 
-            // checkBestInter
+            // CheckWantsView
             // 
-            this.checkBestInter.AutoSize = true;
-            this.checkBestInter.Checked = true;
-            this.checkBestInter.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBestInter.Location = new System.Drawing.Point(12, 262);
-            this.checkBestInter.Margin = new System.Windows.Forms.Padding(6);
-            this.checkBestInter.Name = "checkBestInter";
-            this.checkBestInter.Size = new System.Drawing.Size(325, 29);
-            this.checkBestInter.TabIndex = 16;
-            this.checkBestInter.Text = "check best price international";
-            this.checkBestInter.UseVisualStyleBackColor = true;
-            // 
-            // CheckWants
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1272, 488);
+            this.ClientSize = new System.Drawing.Size(636, 254);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.groupBox4);
-            this.Margin = new System.Windows.Forms.Padding(6);
             this.MinimizeBox = false;
-            this.Name = "CheckWants";
+            this.Name = "CheckWantsView";
             this.ShowIcon = false;
             this.Text = "Check for cheap deals";
             this.Load += new System.EventHandler(this.CheckWants_Load);
@@ -412,5 +414,7 @@
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.CheckBox domnesticCheck;
         private System.Windows.Forms.CheckBox checkBestInter;
+        private System.Windows.Forms.TextBox textBoxUser;
+        private System.Windows.Forms.CheckBox checkBoxUser;
     }
 }

--- a/MKMTool/CheckWantsView.cs
+++ b/MKMTool/CheckWantsView.cs
@@ -209,7 +209,7 @@ namespace MKMTool
                 double maxAllowedPrice = Convert.ToDouble(maxPrice.Text);
                 while (true)
                 { 
-                    String sUrl = "https://www.mkmapi.eu/ws/v2.0/users/" + textBoxUser.Text + "/articles?start=" + start + "&maxResults=1000";
+                    String sUrl = "https://api.cardmarket.com/ws/v2.0/users/" + textBoxUser.Text + "/articles?start=" + start + "&maxResults=1000";
 
                     try
                     {
@@ -291,7 +291,7 @@ namespace MKMTool
         private void checkArticle(string idProduct, string idLanguage, string minCondition, string isFoil,
             string isSigned, string isAltered, string isPlayset, string matchingArticle)
         {
-            var sUrl = "https://www.mkmapi.eu/ws/v2.0/articles/" + idProduct +
+            var sUrl = "https://api.cardmarket.com/ws/v2.0/articles/" + idProduct +
                        "?minCondition=" + minCondition +
                        "&start=0&maxResults=50";
 
@@ -407,7 +407,7 @@ namespace MKMTool
                                 //check Trend Price
                                 var doc3 =
                                     MKMInteract.RequestHelper.makeRequest(
-                                        "https://www.mkmapi.eu/ws/v2.0/products/" + idProduct, "GET");
+                                        "https://api.cardmarket.com/ws/v2.0/products/" + idProduct, "GET");
 
                                 fTrendprice =
                                     Convert.ToDouble(doc3.GetElementsByTagName("TREND")[0].InnerText.Replace(".", ","));
@@ -437,7 +437,7 @@ namespace MKMTool
 
                                     sRequestXML = MKMInteract.RequestHelper.getRequestBody(sRequestXML);
 
-                                    MKMInteract.RequestHelper.makeRequest("https://www.mkmapi.eu/ws/v2.0/shoppingcart",
+                                    MKMInteract.RequestHelper.makeRequest("https://api.cardmarket.com/ws/v2.0/shoppingcart",
                                         "PUT", sRequestXML);
                                 }
                                 catch (Exception eError)

--- a/MKMTool/CheckWantsView.cs
+++ b/MKMTool/CheckWantsView.cs
@@ -34,6 +34,7 @@ using System.Data;
 using System.IO;
 using System.Windows.Forms;
 using System.Xml;
+using System.Globalization;
 
 namespace MKMTool
 {
@@ -149,15 +150,16 @@ namespace MKMTool
 
             foreach (XmlNode article in node)
             {
-                var sArticleID = article["product"]["idProduct"].InnerText;
+                var sProductID = article["product"]["idProduct"].InnerText;
 
                 frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend),
-                    "checking:" + sArticleID + " ...\n");
-
-                //private void checkArticle(string sArticleID, string idLanguage, string minCondition, string isFoil, string isSigned, string isAltered, string isPlayset)
-                checkArticle(sArticleID, article["idLanguage"].InnerText, article["minCondition"].InnerText,
+                    "checking:" + sProductID + " ...\n");
+                
+                checkArticle(sProductID, article["language"]["idLanguage"].InnerText, article["minCondition"].InnerText,
                     article["isFoil"].InnerText, article["isSigned"].InnerText, article["isAltered"].InnerText,
-                    article["isPlayset"].InnerText);
+                    article["isPlayset"].InnerText, "");
+
+                frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend), "Done.\n");
             }
         }
 
@@ -172,52 +174,124 @@ namespace MKMTool
 
             frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend), "Shoping Cart emptied.\n");
         }
+        
 
         private void checkEditionButton_Click(object sender, EventArgs e)
         {
-            var sEdId = (editionBox.SelectedItem as MKMHelpers.ComboboxItem).Value.ToString();
-
-            var sT = dt.Clone();
-
-            var result = dt.Select(string.Format("[Expansion ID] = '{0}'", sEdId));
-
-            foreach (var row in result)
-            {
-                sT.ImportRow(row);
-            }
-
+            checkEditionButton.Enabled = false;
+            checkEditionButton.Text = "Checking cheap deals...";
             var isFoil = "";
             var isSigned = "";
             var isAltered = "";
             var isPlayset = "";
             var minCondition = conditionCombo.Text;
 
-            if (foilBox.CheckState.ToString() == "Checked")
+            if (foilBox.Checked)
                 isFoil = "true";
 
-            if (signedBox.CheckState.ToString() == "Checked")
+            if (signedBox.Checked)
                 isSigned = "true";
 
-            if (alteredBox.CheckState.ToString() == "Checked")
+            if (alteredBox.Checked)
                 isAltered = "true";
 
-            if (playsetBox.CheckState.ToString() == "Checked")
+            if (playsetBox.Checked)
                 isPlayset = "true";
 
-            foreach (DataRow oRecord in sT.Rows)
+
+            if (checkBoxUser.Enabled)
             {
-                frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend),
-                    "Checking: " + oRecord["idProduct"] + "\n");
-                checkArticle(oRecord["idProduct"].ToString(),
-                    (langCombo.SelectedItem as MKMHelpers.ComboboxItem).Value.ToString(), minCondition, isFoil, isSigned,
-                    isAltered, isPlayset);
+                if (domnesticCheck.Checked)
+                    frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend),
+                        "WARNING - domestics only is checked, if the specified seller is from a foreign country, no deals will be found.\n");
+                // Go through the stock of a specified user, checks for cheap deals and add them to the cart.
+                int start = 0;
+                double maxAllowedPrice = Convert.ToDouble(maxPrice.Text);
+                while (true)
+                { 
+                    String sUrl = "https://www.mkmapi.eu/ws/v2.0/users/" + textBoxUser.Text + "/articles?start=" + start + "&maxResults=1000";
+
+                    try
+                    {
+                        // get the users stock, filtered by the selected parameters
+                        var doc2 = MKMInteract.RequestHelper.makeRequest(sUrl, "GET");
+
+                        var node2 = doc2.GetElementsByTagName("article");
+                        String language = (langCombo.SelectedItem as MKMHelpers.ComboboxItem).Value.ToString();
+                        foreach (XmlNode article in node2)
+                        {
+                            if ( // do as much filtering here as possible to reduce the number of API calls
+                                MKMHelpers.IsBetterOrSameCondition(article["condition"].InnerText, conditionCombo.Text) &&
+                                (!foilBox.Checked || article["isFoil"].InnerText == "true") &&
+                                (!playsetBox.Checked || article["isPlayset"].InnerText == "true") &&
+                                (language == "" || article["language"]["idLanguage"].InnerText == language) &&
+                                (!signedBox.Checked || article["isSigned"].InnerText == "true") &&
+                                (!signedBox.Checked || article["isAltered"].InnerText == "true") &&
+                                (maxAllowedPrice >= Convert.ToDouble(article["price"].InnerText, CultureInfo.InvariantCulture))
+                                )
+                            {
+
+                                frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend),
+                                    "Checking: " + article["idProduct"].InnerText + "\n");
+                                checkArticle(article["idProduct"].InnerText,
+                                    language, minCondition, isFoil, isSigned,
+                                    isAltered, isPlayset, article["idArticle"].InnerText);
+
+                                frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend), "Done.\n");
+                            }
+                        }
+                        if (node2.Count != 1000) // there is no additional items to fetch
+                            break;
+                    }
+                    catch (Exception eError)
+                    {
+                        frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend),
+                            "ERR Msg : " + eError.Message + "\n");
+                        frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend), "ERR URL : " + sUrl + "\n");
+
+                        using (var sw = File.AppendText(@".\\error_log.txt"))
+                        {
+                            sw.WriteLine("ERR Msg : " + eError.Message);
+                            sw.WriteLine("ERR URL : " + sUrl);
+                        }
+                    }
+                    start += 1000;
+                }
             }
+            else
+            {
+                var sEdId = editionBox.SelectedItem.ToString();
+
+                var sT = dt.Clone();
+
+                var result = dt.Select(string.Format("[Expansion ID] = '{0}'", sEdId));
+
+                foreach (var row in result)
+                {
+                    sT.ImportRow(row);
+                }
+
+                foreach (DataRow oRecord in sT.Rows)
+                {
+                    frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend),
+                        "Checking: " + oRecord["idProduct"] + "\n");
+                    checkArticle(oRecord["idProduct"].ToString(),
+                        (langCombo.SelectedItem as MKMHelpers.ComboboxItem).Value.ToString(), minCondition, isFoil, isSigned,
+                        isAltered, isPlayset, "");
+
+                    frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend), "Done.\n");
+                }
+            }
+
+            checkEditionButton.Text = "Check now";
+            checkEditionButton.Enabled = true;
         }
 
-        private void checkArticle(string sArticleID, string idLanguage, string minCondition, string isFoil,
-            string isSigned, string isAltered, string isPlayset)
+        // idArticle - if not empty, article will be added to shopping cart only if it is matching the specified idArticle. used for searching for cheap deals by user
+        private void checkArticle(string idProduct, string idLanguage, string minCondition, string isFoil,
+            string isSigned, string isAltered, string isPlayset, string matchingArticle)
         {
-            var sUrl = "https://www.mkmapi.eu/ws/v2.0/articles/" + sArticleID +
+            var sUrl = "https://www.mkmapi.eu/ws/v2.0/articles/" + idProduct +
                        "?minCondition=" + minCondition +
                        "&start=0&maxResults=50";
 
@@ -276,23 +350,16 @@ namespace MKMTool
                      * false    = no
                      */
 
+                    if (offer["seller"]["address"]["country"].InnerText != MKMHelpers.sMyOwnCountry && domnesticCheck.Checked)
+                        continue;
                     // save chepest price found anywhere
+                    aPrices[counter] = Convert.ToSingle(offer["price"].InnerText, CultureInfo.InvariantCulture);
                     if (noBestPrice)
                     {
-                        bestPriceInternational = Convert.ToSingle(offer["price"].InnerText.Replace(".", ","));
+                        bestPriceInternational = aPrices[counter];
                         noBestPrice = false;
                     }
-
-                    if (offer["seller"]["address"]["country"].InnerText != MKMHelpers.sMyOwnCountry)
-                    {
-                        if (domnesticCheck.Checked)
-                        {
-                            continue;
-                        }
-                    }
-
-                    var sXPrice = offer["price"].InnerText.Replace(".", ",");
-                    aPrices[counter] = Convert.ToSingle(sXPrice);
+                    
 
                     if (aPrices[0] + (float) Convert.ToDouble(shipAddition.Text) >
                         (float) Convert.ToDouble(maxPrice.Text))
@@ -304,15 +371,18 @@ namespace MKMTool
                     if (counter == 0)
                     {
                         bestPriceArticle = offer["idArticle"].InnerText;
+                        // if looking for matching article, no point to continue if it is not the cheapest - perhaps could be modified to pick things that are among matching?
+                        if (matchingArticle != "" && matchingArticle != bestPriceArticle)
+                            break;
                     }
 
                     counter++;
 
                     if (counter == 3)
-                    {
-                        double factor = (float) Convert.ToDouble(percentText.Text);
+                    {                        
+                        double factor = (float)Convert.ToDouble(percentText.Text);
 
-                        factor = factor/100 + 1;
+                        factor = factor / 100 + 1;
 
                         //double f1 = Math.Round(((aPrices[0] * factor) + (float)Convert.ToDouble(shipAddition.Text)), 2);
 
@@ -320,14 +390,14 @@ namespace MKMTool
                             "Price 1: " + aPrices[0] + " Price 2: " + aPrices[1] + "\n");
                         frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend),
                             "Factor Price 1: " +
-                            Math.Round(aPrices[0]*factor + (float) Convert.ToDouble(shipAddition.Text), 2)
+                            Math.Round(aPrices[0] * factor + (float)Convert.ToDouble(shipAddition.Text), 2)
                             + " Factor Price 2: " +
-                            Math.Round(aPrices[1]*factor + (float) Convert.ToDouble(shipAddition.Text), 2) + "\n");
+                            Math.Round(aPrices[1] * factor + (float)Convert.ToDouble(shipAddition.Text), 2) + "\n");
 
                         //X% under others
                         if (
-                            (aPrices[0]*factor + (float) Convert.ToDouble(shipAddition.Text) < aPrices[1])
-                            && (aPrices[0]*factor + (float) Convert.ToDouble(shipAddition.Text) < aPrices[2])
+                            (aPrices[0] * factor + (float)Convert.ToDouble(shipAddition.Text) < aPrices[1])
+                            && (aPrices[0] * factor + (float)Convert.ToDouble(shipAddition.Text) < aPrices[2])
                             )
                         {
                             double fTrendprice = 100000; // fictive price 
@@ -337,7 +407,7 @@ namespace MKMTool
                                 //check Trend Price
                                 var doc3 =
                                     MKMInteract.RequestHelper.makeRequest(
-                                        "https://www.mkmapi.eu/ws/v2.0/products/" + sArticleID, "GET");
+                                        "https://www.mkmapi.eu/ws/v2.0/products/" + idProduct, "GET");
 
                                 fTrendprice =
                                     Convert.ToDouble(doc3.GetElementsByTagName("TREND")[0].InnerText.Replace(".", ","));
@@ -350,14 +420,14 @@ namespace MKMTool
                             if (domnesticCheck.Checked)
                             {
                                 // is best price international (+/-5%)?
-                                if (!(aPrices[0]*0.95 <= bestPriceInternational))
+                                if (!(aPrices[0] * 0.95 <= bestPriceInternational))
                                 {
                                     break;
                                 }
                             }
 
                             // X% under TREND
-                            if (aPrices[0]*factor < fTrendprice)
+                            if (aPrices[0] * factor < fTrendprice)
                             {
                                 frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend),
                                     "Found cheap offer " + bestPriceArticle + "\n");
@@ -396,12 +466,16 @@ namespace MKMTool
                     sw.WriteLine("ERR URL : " + sUrl);
                 }
             }
-
-            frm1.logBox.Invoke(new MainView.logboxAppendCallback(frm1.logBoxAppend), "Done.\n");
         }
 
         private void CheckWants_Load(object sender, EventArgs e)
         {
+        }
+
+        private void checkBoxUser_CheckedChanged(object sender, EventArgs e)
+        {
+            textBoxUser.Enabled = checkBoxUser.Checked;
+            editionBox.Enabled = !checkBoxUser.Checked;
         }
     }
 }

--- a/MKMTool/MKMBot.cs
+++ b/MKMTool/MKMBot.cs
@@ -429,8 +429,12 @@ namespace MKMTool
                 if (article["condition"] != null && article["idArticle"].InnerText != null && article["price"].InnerText != null)
                 {
                     var sUrl = "http://not.initilaized";
+                    bool changeMT = false;
                     if (article["condition"].InnerText == "MT") // treat mint cards as near mint for pricing purposes
+                    {
                         article["condition"].InnerText = "NM";
+                        changeMT = true;
+                    }
                     try
                     {
                         var sArticleID = article["idProduct"].InnerText;
@@ -577,6 +581,8 @@ namespace MKMTool
                                         ", based on " + (lastMatch + 1) + " items" +
                                         (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
 
+                            if (changeMT)
+                                article["condition"].InnerText = "MT";
                             sRequestXML += MKMInteract.RequestHelper.changeStockArticleBody(article, sNewPrice);
                         }
                     }

--- a/MKMTool/MKMBot.cs
+++ b/MKMTool/MKMBot.cs
@@ -415,7 +415,8 @@ namespace MKMTool
                 if (article["condition"] != null && article["idArticle"].InnerText != null && article["price"].InnerText != null)
                 {
                     var sUrl = "http://not.initilaized";
-
+                    if (article["condition"].InnerText == "MT") // treat mint cards as near mint for pricing purposes
+                        article["condition"].InnerText = "NM";
                     try
                     {
                         var sArticleID = article["idProduct"].InnerText;
@@ -582,7 +583,9 @@ namespace MKMTool
                                 break;
                             }
                         }
-                        if (priceEstimation > 0) // is < 0 if change was too large
+                        if (priceEstimation > 0 // is < 0 if change was too large
+                            && Math.Abs(priceEstimation - dOldPrice) != Double.Epsilon // don't update if it did not change - clearer log
+                            )
                         {
                             if (settings.logUpdated && (settings.logSmallPriceChange ||
                                 (priceEstimation > dOldPrice + settings.priceMinRarePrice || priceEstimation < dOldPrice - settings.priceMinRarePrice)))

--- a/MKMTool/MKMBot.cs
+++ b/MKMTool/MKMBot.cs
@@ -405,19 +405,28 @@ namespace MKMTool
             //frm1.logBox.Invoke(new logboxAppendCallback(this.logBoxAppend), Application.CurrentCulture.EnglishName + "\n", frm1);
 
             var debugCounter = 0;
-            
+            List<XmlNode> articles = new List<XmlNode>();
             string sRequestXML = "";
-            var doc = MKMInteract.RequestHelper.readStock();
-
-            //logBox.AppendText(OutputFormat.PrettyXml(doc.OuterXml));
-
-            var node = doc.GetElementsByTagName("article");
-
-            foreach (XmlNode article in node)
+            XmlNodeList result;
+            var start = 1;
+            do
             {
-                debugCounter++;
+                var doc = MKMInteract.RequestHelper.readStock(start);
 
+                //logBox.AppendText(OutputFormat.PrettyXml(doc.OuterXml));
+                result = doc.GetElementsByTagName("article");
+                foreach (XmlNode article in result)
+                {
+                    articles.Add(article);
+                }
+                start += result.Count;
+            } while (result.Count == 100);
+
+            int putCounter = 0; 
+            foreach (XmlNode article in articles)
+            {
 #if (DEBUG)
+                debugCounter++;
                 if (debugCounter > 3)
                 {
                     frm1.logBox.AppendText("DEBUG MODE - EXITING AFTER 3\n");
@@ -428,181 +437,19 @@ namespace MKMTool
                 // -> check if condition exists to see if this is a single card or something else
                 if (article["condition"] != null && article["idArticle"].InnerText != null && article["price"].InnerText != null)
                 {
-                    var sUrl = "http://not.initilaized";
-                    bool changeMT = false;
-                    if (article["condition"].InnerText == "MT") // treat mint cards as near mint for pricing purposes
+                    string update = checkArticle(article, frm1);
+                    if (update != null)
                     {
-                        article["condition"].InnerText = "NM";
-                        changeMT = true;
-                    }
-                    try
-                    {
-                        var sArticleID = article["idProduct"].InnerText;
-
-                        /*XmlDocument doc2 = MKMInteract.RequestHelper.makeRequest("https://www.mkmapi.eu/ws/v2.0/products/" + sArticleID, "GET");
-
-                        logBox.AppendText(OutputFormat.PrettyXml(doc2.OuterXml));*/
-                        
-                        sUrl = "https://www.mkmapi.eu/ws/v2.0/articles/" + sArticleID +
-                                    "?idLanguage=" + article["language"]["idLanguage"].InnerText +
-                                    "&minCondition=" + article["condition"].InnerText + "&start=0&maxResults=150&isFoil="
-                                    + article["isFoil"].InnerText +
-                                    "&isSigned=" + article["isSigned"].InnerText +
-                                    "&isAltered=" + article["isAltered"].InnerText;
-
-                        //string sUrl = "https://www.mkmapi.eu/ws/v2.0/articles/" + sArticleID;
-                        //string sUrl = "https://www.mkmapi.eu/ws/v2.0/articles/" + sArticleID + "?start=0&maxResults=250";
-
-
-                        var doc2 = MKMInteract.RequestHelper.makeRequest(sUrl, "GET");
-
-                        XmlNodeList similarItems = doc2.GetElementsByTagName("article");
-                        
-                        List<double> prices = new List<double>();
-                        string sOldPrice = article["price"].InnerText;
-                        double dOldPrice = Convert.ToDouble(sOldPrice, CultureInfo.InvariantCulture);
-                        int lastMatch = -1;
-                        bool ignoreSellersCountry = false;
-                        TraverseResult res = traverseSimilarItems(similarItems, article, ignoreSellersCountry, ref lastMatch, ref prices);
-                        if (settings.searchWorldwide && res == TraverseResult.NotEnoughSimilars) // if there isn't enough similar items being sold in seller's country, check other countries as well
+                        sRequestXML += update;
+                        // max 100 articles is allowed to be part of a PUT call - if we are there, call it
+                        if (putCounter > 98 && !settings.testMode)
                         {
-                            ignoreSellersCountry = true;
-                            prices.Clear();
-                            lastMatch = -1;
-                            res = traverseSimilarItems(similarItems, article, ignoreSellersCountry, ref lastMatch, ref prices);
-                        }
-                        double priceEstimation = 0;
-                        if (settings.priceSetPriceBy == PriceSetMethod.ByPercentageOfLowestPrice && res == TraverseResult.SequenceFound)
-                        {
-                            priceEstimation = prices[0] * settings.priceFactor;
-                        }
-                        else if (res == TraverseResult.Culled)
-                        {
-                            if (settings.logLessThanMinimum)
-                                frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                                        sArticleID + ">>> " + article["product"]["enName"].InnerText +
-                                        " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
-                                        "Current Price: " + article["price"].InnerText + ", unchanged, only " +
-                                        (lastMatch + 1) + " similar items found (but some outliers were culled)" +
-                                        (ignoreSellersCountry ? " - worldwide search!" : "")+ Environment.NewLine, frm1);
-                            continue;
-                        }
-                        else if (res == TraverseResult.HighVariance)
-                        {
-                            if (settings.logHighPriceVariance) // this signifies that prices were not updated due to too high variance
-                                frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                                    sArticleID + ">>> " + article["product"]["enName"].InnerText +
-                                    " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
-                                    "NOT UPDATED - variance of prices among cheapest similar items is too high" +
-                                    (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
-                            continue;
-                        }
-                        else if (res == TraverseResult.NotEnoughSimilars)
-                        {
-                            if (settings.logLessThanMinimum)
-                                frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                                    sArticleID + ">>> " + article["product"]["enName"].InnerText +
-                                    " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
-                                    "Current Price: " + article["price"].InnerText + ", unchanged, only " +
-                                    (lastMatch + 1) + " similar items found" +
-                                    (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
-                            continue;
-                        }
-                        else if (settings.condAcceptance == AcceptedCondition.SomeMatchesAbove && lastMatch + 1 < settings.priceMinSimilarItems)
-                            // at least one matching item above non-matching is required -> if there wasn't, the last match might have been before min. # of items
-
-                        {
-                            if (settings.logLessThanMinimum)
-                                frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                                    sArticleID + ">>> " + article["product"]["enName"].InnerText +
-                                    " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
-                                    "Current Price: " + article["price"].InnerText + ", unchanged, only " +
-                                    (lastMatch + 1) + " similar items with an item with matching condition above them were found" +
-                                    (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
-                            continue;
+                            sendPriceUpdate(sRequestXML, frm1);
+                            putCounter = 0;
+                            sRequestXML = "";
                         }
                         else
-                        {
-                            // if any condition is allowed, use the whole sequence
-                            // if only matching is allowed, use whole sequence as well because it is only matching items
-                            if (settings.condAcceptance != AcceptedCondition.SomeMatchesAbove)
-                                lastMatch = prices.Count - 1;
-                            if (settings.priceSetPriceBy == PriceSetMethod.ByPercentageOfHighestPrice)
-                                priceEstimation = prices[lastMatch] * settings.priceFactor;
-                            else // estimation by average
-                            {
-                                for (int i = 0; i <= lastMatch; i++)
-                                    priceEstimation += prices[i]; // priceEstimation is initialized to 0 above
-                                priceEstimation /= (lastMatch + 1);
-                                // linear interpolation between average (currently stored in priceEstimation) and highest price in the sequence
-                                if (settings.priceFactor > 0.5)
-                                    priceEstimation += (prices[lastMatch] - priceEstimation) * (settings.priceFactor - 0.5) * 2;
-                                else if (settings.priceFactor < 0.5) // linear interpolation between lowest price and average
-                                    priceEstimation = prices[0] + (priceEstimation - prices[0]) * (settings.priceFactor) * 2;
-                            }
-                        }
-                        if (priceEstimation < settings.priceMinRarePrice && 
-                            (article["product"]["rarity"].InnerText == "Rare" || article["product"]["rarity"].InnerText == "Mythic"))
-                            priceEstimation = settings.priceMinRarePrice;
-
-                        // check the estimation is OK
-                        string sNewPrice = priceEstimation.ToString("f2", CultureInfo.InvariantCulture);
-
-                        // check it is not above the max price change limits
-                        foreach (var limits in settings.priceMaxChangeLimits)
-                        {
-                            if (dOldPrice < limits.Key)
-                            {
-                                if (Math.Abs(dOldPrice - priceEstimation) > dOldPrice * limits.Value)
-                                {
-                                    priceEstimation = -1;
-                                    if (settings.logHighPriceVariance)
-                                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                                            sArticleID + ">>> " + article["product"]["enName"].InnerText +
-                                            " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
-                                            "NOT UPDATED - change too large: Current Price: "
-                                            + sOldPrice + ", Calcualted Price:" + sNewPrice +
-                                            (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
-
-                                }
-                                break;
-                            }
-                        }
-                        if (priceEstimation > 0 // is < 0 if change was too large
-                            && Math.Abs(priceEstimation - dOldPrice) != Double.Epsilon // don't update if it did not change - clearer log
-                            )
-                        {
-                            if (settings.logUpdated && (settings.logSmallPriceChange ||
-                                (priceEstimation > dOldPrice + settings.priceMinRarePrice || priceEstimation < dOldPrice - settings.priceMinRarePrice)))
-                                    frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                                        sArticleID + ">>> " + article["product"]["enName"].InnerText +
-                                        " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
-                                        "Current Price: " + sOldPrice + ", Calcualted Price:" + sNewPrice +
-                                        ", based on " + (lastMatch + 1) + " items" +
-                                        (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
-
-                            if (changeMT)
-                                article["condition"].InnerText = "MT";
-                            sRequestXML += MKMInteract.RequestHelper.changeStockArticleBody(article, sNewPrice);
-                        }
-                    }
-                    catch (Exception eError)
-                    {
-
-#if (DEBUG)
-                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                            "ERR at  : " + article["product"]["enName"].InnerText + "\n", frm1);
-                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                            "ERR Msg : " + eError.Message + "\n", frm1);
-                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend), "ERR URL : " + sUrl + "\n", frm1);
-#endif
-                        using (var sw = File.AppendText(@".\\error_log.txt"))
-                        {
-                            sw.WriteLine("ERR at  : " + article["product"]["enName"].InnerText);
-                            sw.WriteLine("ERR Msg : " + eError.Message);
-                            sw.WriteLine("ERR URL : " + sUrl);
-                        }
-
+                            putCounter++;
                     }
                 }
             }
@@ -615,50 +462,7 @@ namespace MKMTool
             }
             else if (sRequestXML.Length > 0)
             {
-                sRequestXML = MKMInteract.RequestHelper.getRequestBody(sRequestXML);
-
-                //logBox.AppendText("final Request:\n");
-                //logBox.AppendText(OutputFormat.PrettyXml(sRequestXML));
-
-                XmlDocument rdoc = null;
-
-                try
-                {
-                    rdoc = MKMInteract.RequestHelper.makeRequest("https://www.mkmapi.eu/ws/v2.0/stock", "PUT",
-                        sRequestXML);
-                }
-                catch (Exception eError)
-                {
-                    frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend), "ERR Msg : " + eError.Message + "\n",
-                        frm1);
-                }
-
-                var xUpdatedArticles = rdoc.GetElementsByTagName("updatedArticles");
-                var xNotUpdatedArticles = rdoc.GetElementsByTagName("notUpdatedArticles");
-
-                var iUpdated = xUpdatedArticles.Count;
-                var iFailed = xNotUpdatedArticles.Count;
-
-                if (iFailed == 1)
-                {
-                    iFailed = 0;
-                }
-
-                frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                    debugCounter + "/" + iUpdated + " Articles updated successfully, " + iFailed + " failed" + Environment.NewLine, frm1);
-                
-                if (iFailed > 1)
-                {
-                    try
-                    {
-                        File.WriteAllText(@".\\log" + DateTime.Now.ToString("ddMMyyyy-HHmm") + ".log", rdoc.ToString());
-                    }
-                    catch (Exception eError)
-                    {
-                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend), "ERR Msg : " + eError.Message + Environment.NewLine,
-                            frm1);
-                    }
-                }
+                sendPriceUpdate(sRequestXML, frm1);
             }
             else
             {
@@ -669,7 +473,238 @@ namespace MKMTool
             String timeStamp = GetTimestamp(DateTime.Now);
 
             frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
-                "Last Run finsihed: " + timeStamp + Environment.NewLine, frm1);
+                "Last Run finished: " + timeStamp + Environment.NewLine, frm1);
+        }
+
+        /// <summary>
+        /// Sends the price update to MKM.
+        /// </summary>
+        /// <param name="sRequestXML">The raw (= not as a api request yet) xml with all article updates. Check that it is not empty before calling this.</param>
+        /// <param name="frm1">The main window - log messages will be written there.</param>
+        private void sendPriceUpdate(string sRequestXML, MainView frm1)
+        {
+            sRequestXML = MKMInteract.RequestHelper.getRequestBody(sRequestXML);
+
+            //logBox.AppendText("final Request:\n");
+            //logBox.AppendText(OutputFormat.PrettyXml(sRequestXML));
+
+            XmlDocument rdoc = null;
+
+            try
+            {
+                rdoc = MKMInteract.RequestHelper.makeRequest("https://api.cardmarket.com/ws/v2.0/stock", "PUT",
+                    sRequestXML);
+            }
+            catch (Exception eError)
+            {
+                frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend), "ERR Msg: " + eError.Message + "\n",
+                    frm1);
+            }
+
+            var xUpdatedArticles = rdoc.GetElementsByTagName("updatedArticles");
+            var xNotUpdatedArticles = rdoc.GetElementsByTagName("notUpdatedArticles");
+
+            var iUpdated = xUpdatedArticles.Count;
+            var iFailed = xNotUpdatedArticles.Count;
+
+            if (iFailed == 1)
+            {
+                iFailed = 0;
+            }
+
+            frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                iUpdated + " articles updated successfully, " + iFailed + " failed" + Environment.NewLine, frm1);
+
+            if (iFailed > 1)
+            {
+                try
+                {
+                    File.WriteAllText(@".\\log" + DateTime.Now.ToString("ddMMyyyy-HHmm") + ".log", rdoc.ToString());
+                }
+                catch (Exception eError)
+                {
+                    frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend), "ERR Msg : " + eError.Message + Environment.NewLine,
+                        frm1);
+                }
+            }
+        }
+
+        private string checkArticle(XmlNode article, MainView frm1)
+        {
+            var sUrl = "http://not.initilaized";
+            bool changeMT = false;
+            if (article["condition"].InnerText == "MT") // treat mint cards as near mint for pricing purposes
+            {
+                article["condition"].InnerText = "NM";
+                changeMT = true;
+            }
+            try
+            {
+                var sArticleID = article["idProduct"].InnerText;
+
+                /*XmlDocument doc2 = MKMInteract.RequestHelper.makeRequest("https://api.cardmarket.com/ws/v2.0/products/" + sArticleID, "GET");
+
+                logBox.AppendText(OutputFormat.PrettyXml(doc2.OuterXml));*/
+
+                sUrl = "https://api.cardmarket.com/ws/v2.0/articles/" + sArticleID +
+                            "?idLanguage=" + article["language"]["idLanguage"].InnerText +
+                            "&minCondition=" + article["condition"].InnerText + "&start=0&maxResults=150&isFoil="
+                            + article["isFoil"].InnerText +
+                            "&isSigned=" + article["isSigned"].InnerText +
+                            "&isAltered=" + article["isAltered"].InnerText;
+                
+                var doc2 = MKMInteract.RequestHelper.makeRequest(sUrl, "GET");
+
+                XmlNodeList similarItems = doc2.GetElementsByTagName("article");
+
+                List<double> prices = new List<double>();
+                string sOldPrice = article["price"].InnerText;
+                double dOldPrice = Convert.ToDouble(sOldPrice, CultureInfo.InvariantCulture);
+                int lastMatch = -1;
+                bool ignoreSellersCountry = false;
+                TraverseResult res = traverseSimilarItems(similarItems, article, ignoreSellersCountry, ref lastMatch, ref prices);
+                if (settings.searchWorldwide && res == TraverseResult.NotEnoughSimilars) // if there isn't enough similar items being sold in seller's country, check other countries as well
+                {
+                    ignoreSellersCountry = true;
+                    prices.Clear();
+                    lastMatch = -1;
+                    res = traverseSimilarItems(similarItems, article, ignoreSellersCountry, ref lastMatch, ref prices);
+                }
+                double priceEstimation = 0;
+                if (settings.priceSetPriceBy == PriceSetMethod.ByPercentageOfLowestPrice && res == TraverseResult.SequenceFound)
+                {
+                    priceEstimation = prices[0] * settings.priceFactor;
+                }
+                else if (res == TraverseResult.Culled)
+                {
+                    if (settings.logLessThanMinimum)
+                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                                sArticleID + ">>> " + article["product"]["enName"].InnerText +
+                                " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
+                                "Current Price: " + article["price"].InnerText + ", unchanged, only " +
+                                (lastMatch + 1) + " similar items found (but some outliers were culled)" +
+                                (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
+                    return null;
+                }
+                else if (res == TraverseResult.HighVariance)
+                {
+                    if (settings.logHighPriceVariance) // this signifies that prices were not updated due to too high variance
+                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                            sArticleID + ">>> " + article["product"]["enName"].InnerText +
+                            " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
+                            "NOT UPDATED - variance of prices among cheapest similar items is too high" +
+                            (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
+                    return null;
+                }
+                else if (res == TraverseResult.NotEnoughSimilars)
+                {
+                    if (settings.logLessThanMinimum)
+                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                            sArticleID + ">>> " + article["product"]["enName"].InnerText +
+                            " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
+                            "Current Price: " + article["price"].InnerText + ", unchanged, only " +
+                            (lastMatch + 1) + " similar items found" +
+                            (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
+                    return null;
+                }
+                else if (settings.condAcceptance == AcceptedCondition.SomeMatchesAbove && lastMatch + 1 < settings.priceMinSimilarItems)
+                // at least one matching item above non-matching is required -> if there wasn't, the last match might have been before min. # of items
+
+                {
+                    if (settings.logLessThanMinimum)
+                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                            sArticleID + ">>> " + article["product"]["enName"].InnerText +
+                            " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
+                            "Current Price: " + article["price"].InnerText + ", unchanged, only " +
+                            (lastMatch + 1) + " similar items with an item with matching condition above them were found" +
+                            (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
+                    return null;
+                }
+                else
+                {
+                    // if any condition is allowed, use the whole sequence
+                    // if only matching is allowed, use whole sequence as well because it is only matching items
+                    if (settings.condAcceptance != AcceptedCondition.SomeMatchesAbove)
+                        lastMatch = prices.Count - 1;
+                    if (settings.priceSetPriceBy == PriceSetMethod.ByPercentageOfHighestPrice)
+                        priceEstimation = prices[lastMatch] * settings.priceFactor;
+                    else // estimation by average
+                    {
+                        for (int i = 0; i <= lastMatch; i++)
+                            priceEstimation += prices[i]; // priceEstimation is initialized to 0 above
+                        priceEstimation /= (lastMatch + 1);
+                        // linear interpolation between average (currently stored in priceEstimation) and highest price in the sequence
+                        if (settings.priceFactor > 0.5)
+                            priceEstimation += (prices[lastMatch] - priceEstimation) * (settings.priceFactor - 0.5) * 2;
+                        else if (settings.priceFactor < 0.5) // linear interpolation between lowest price and average
+                            priceEstimation = prices[0] + (priceEstimation - prices[0]) * (settings.priceFactor) * 2;
+                    }
+                }
+                if (priceEstimation < settings.priceMinRarePrice &&
+                    (article["product"]["rarity"].InnerText == "Rare" || article["product"]["rarity"].InnerText == "Mythic"))
+                    priceEstimation = settings.priceMinRarePrice;
+
+                // check the estimation is OK
+                string sNewPrice = priceEstimation.ToString("f2", CultureInfo.InvariantCulture);
+
+                // check it is not above the max price change limits
+                foreach (var limits in settings.priceMaxChangeLimits)
+                {
+                    if (dOldPrice < limits.Key)
+                    {
+                        if (Math.Abs(dOldPrice - priceEstimation) > dOldPrice * limits.Value)
+                        {
+                            priceEstimation = -1;
+                            if (settings.logHighPriceVariance)
+                                frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                                    sArticleID + ">>> " + article["product"]["enName"].InnerText +
+                                    " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
+                                    "NOT UPDATED - change too large: Current Price: "
+                                    + sOldPrice + ", Calcualted Price:" + sNewPrice +
+                                    (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
+
+                        }
+                        break;
+                    }
+                }
+                if (priceEstimation > 0 // is < 0 if change was too large
+                    && Math.Abs(priceEstimation - dOldPrice) != Double.Epsilon // don't update if it did not change - clearer log
+                    )
+                {
+                    if (settings.logUpdated && (settings.logSmallPriceChange ||
+                        (priceEstimation > dOldPrice + settings.priceMinRarePrice || priceEstimation < dOldPrice - settings.priceMinRarePrice)))
+                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                            sArticleID + ">>> " + article["product"]["enName"].InnerText +
+                            " (" + article["product"]["expansion"].InnerText + ", " + article["language"]["languageName"].InnerText + ")" + Environment.NewLine +
+                            "Current Price: " + sOldPrice + ", Calcualted Price:" + sNewPrice +
+                            ", based on " + (lastMatch + 1) + " items" +
+                            (ignoreSellersCountry ? " - worldwide search!" : "") + Environment.NewLine, frm1);
+
+                    if (changeMT)
+                        article["condition"].InnerText = "MT";
+
+                    return MKMInteract.RequestHelper.changeStockArticleBody(article, sNewPrice);
+                }
+            }
+            catch (Exception eError)
+            {
+
+#if (DEBUG)
+                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                            "ERR at  : " + article["product"]["enName"].InnerText + "\n", frm1);
+                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend),
+                            "ERR Msg : " + eError.Message + "\n", frm1);
+                        frm1.logBox.Invoke(new logboxAppendCallback(logBoxAppend), "ERR URL : " + sUrl + "\n", frm1);
+#endif
+                using (var sw = File.AppendText(@".\\error_log.txt"))
+                {
+                    sw.WriteLine("ERR at  : " + article["product"]["enName"].InnerText);
+                    sw.WriteLine("ERR Msg : " + eError.Message);
+                    sw.WriteLine("ERR URL : " + sUrl);
+                }
+
+            }
+            return null;
         }
 
         private TraverseResult traverseSimilarItems(XmlNodeList similarItems, XmlNode article, bool ignoreSellersCountry,
@@ -780,7 +815,7 @@ namespace MKMTool
             {
                 do
                 {
-                    var doc = MKMInteract.RequestHelper.makeRequest("https://www.mkmapi.eu/ws/v1.1/output.xml/orders/2/" + iType + "/" + iPage, "GET");
+                    var doc = MKMInteract.RequestHelper.makeRequest("https://api.cardmarket.com/ws/v1.1/output.xml/orders/2/" + iType + "/" + iPage, "GET");
 
                     count = doc.SelectNodes("response/order").Count;
 

--- a/MKMTool/MKMHelpers.cs
+++ b/MKMTool/MKMHelpers.cs
@@ -55,6 +55,42 @@ namespace MKMTool
 
         private static DataTable dt = new DataTable();
 
+        /// <summary>
+        /// Converts the condition from string to int as.
+        /// </summary>
+        /// <param name="cond">The condition as two letter code.</param>
+        /// <returns>5 for MT or NM, 4 for EX, 3 for GD, 2 for LP, 1 for PL, 0 for PO.</returns>
+        private static int convertCondition(String cond)
+        {
+            if (cond == "EX")
+                return 4;
+            else if (cond == "GD")
+                return 3;
+            else if (cond == "LP")
+                return 2;
+            else if (cond == "PL")
+                return 1;
+            else if (cond == "PO")
+                return 0;
+            return 5;
+        }
+
+        /// <summary>
+        /// Determines whether the specified condition is better than the reference condition.
+        /// Mint and Near Mint are considered to be the same.
+        /// According to API: (MT for Mint > NM for Near Mint > EX for Exellent > GD for Good > LP for Light Played > PL for Played > PO for Poor) 
+        /// </summary>
+        /// <param name="itemCond">Card condition.</param>
+        /// <param name="reference">The reference condition.</param>
+        /// <returns>
+        ///   <c>true</c> if <c>itemCond</c> is in better or same conditions than the <c>reference</c>; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsBetterOrSameCondition(String itemCond, String reference)
+        {
+            return convertCondition(itemCond) >= convertCondition(reference);
+
+        }
+
         public static Dictionary<string, string> dLanguages = new Dictionary<string, string>
         {
             {

--- a/MKMTool/MKMHelpers.cs
+++ b/MKMTool/MKMHelpers.cs
@@ -289,8 +289,6 @@ namespace MKMTool
 
                     for (i = 0; i < table.Columns.Count; i++)
                     {
-                        var usesColumnDefault = true;
-
                         sql.AppendFormat(" \"{0}\"", table.Columns[i].ColumnName);
 
                         iQm = iQm + "@" + rgx.Replace(table.Columns[i].ColumnName, "");
@@ -337,8 +335,6 @@ namespace MKMTool
 
             for (var i = 0; i < table.Columns.Count; i++)
             {
-                var usesColumnDefault = true;
-
                 sql.AppendFormat(" \"{0}\"", table.Columns[i].ColumnName);
 
                 switch (table.Columns[i].DataType.ToString().ToUpper())
@@ -383,7 +379,7 @@ namespace MKMTool
         {
             if (!File.Exists(@".\\mkminventory.csv"))
             {
-                var doc = MKMInteract.RequestHelper.makeRequest("https://www.mkmapi.eu/ws/v2.0/productlist", "GET");
+                var doc = MKMInteract.RequestHelper.makeRequest("https://api.cardmarket.com/ws/v2.0/productlist", "GET");
 
                 var node = doc.GetElementsByTagName("response");
 

--- a/MKMTool/MKMInteract.cs
+++ b/MKMTool/MKMInteract.cs
@@ -143,37 +143,37 @@ namespace MKMTool
 
             public static XmlDocument getAccount()
             {
-                return makeRequest("https://www.mkmapi.eu/ws/v2.0/account", "GET");
+                return makeRequest("https://api.cardmarket.com/ws/v2.0/account", "GET");
             }
 
             public static XmlDocument getWantsLists()
             {
-                return makeRequest("https://www.mkmapi.eu/ws/v2.0/wantslist", "GET");
+                return makeRequest("https://api.cardmarket.com/ws/v2.0/wantslist", "GET");
             }
 
             public static XmlDocument getWantsListByID(string sID)
             {
-                return makeRequest("https://www.mkmapi.eu/ws/v2.0/wantslist/" + sID, "GET");
+                return makeRequest("https://api.cardmarket.com/ws/v2.0/wantslist/" + sID, "GET");
             }
 
-            public static XmlDocument readStock()
+            public static XmlDocument readStock(int start = 1)
             {
-                return makeRequest("https://www.mkmapi.eu/ws/v2.0/stock", "GET");
+                return makeRequest("https://api.cardmarket.com/ws/v2.0/stock/" + start, "GET");
             }
 
             public static XmlDocument emptyCart()
             {
-                return makeRequest("https://www.mkmapi.eu/ws/v2.0/shoppingcart", "DELETE");
+                return makeRequest("https://api.cardmarket.com/ws/v2.0/shoppingcart", "DELETE");
             }
 
             public static XmlDocument getExpansionsSingles(string ExpansionID)
             {
-                return makeRequest("https://www.mkmapi.eu/ws/v2.0/expansions/" + ExpansionID + "/singles", "GET"); ;
+                return makeRequest("https://api.cardmarket.com/ws/v2.0/expansions/" + ExpansionID + "/singles", "GET"); ;
             }
 
             public static XmlDocument getExpansions(string sGameID)
             {
-                return makeRequest("https://www.mkmapi.eu/ws/v2.0/games/" + sGameID + "/expansions", "GET");
+                return makeRequest("https://api.cardmarket.com/ws/v2.0/games/" + sGameID + "/expansions", "GET");
             }
         }
     }

--- a/MKMTool/MKMInteract.cs
+++ b/MKMTool/MKMInteract.cs
@@ -102,7 +102,7 @@ namespace MKMTool
                                  "<idArticle>" + xNode["idArticle"].InnerText + "</idArticle>" +
                                  "<price>" + sNewPrice + "</price>" +
                                  "<idLanguage>" + xNode["language"]["idLanguage"].InnerText + "</idLanguage>" +
-                                 "<comments></comments>" +
+                                 "<comments>" + xNode["comments"].InnerText + " </comments>" +
                                  "<count>" + xNode["count"].InnerText + "</count>" +
                                  "<condition>" + xNode["condition"].InnerText + "</condition>" +
                                  "</article>";

--- a/MKMTool/StockView.cs
+++ b/MKMTool/StockView.cs
@@ -58,15 +58,38 @@ namespace MKMTool
 
             try
             {
-                var doc = MKMInteract.RequestHelper.readStock();
+                int start = 1;
+                var articles = new DataTable();
+                Boolean first = true;
+                while (true)
+                {
+                    var doc = MKMInteract.RequestHelper.readStock(start);
+                    var xmlReader = new XmlNodeReader(doc);
+                    var ds = new DataSet();
+                    ds.ReadXml(xmlReader);
+                    var articleTable = ds.Tables[0];
+                    var elementCount = articleTable.Rows.Count;
+                    if (first)
+                    {
+                        articles = articleTable;
+                        first = false;
+                    }
+                    else
+                    {
+                        foreach (DataRow dr in articleTable.Rows)
+                        {
+                            dr["article_Id"] = articles.Rows.Count;
+                            articles.ImportRow(dr);
+                        }
+                    }
+                    if (elementCount != 100)
+                    {
+                        break;
+                    }
+                    start += elementCount;
+                }
 
-                var xmlReader = new XmlNodeReader(doc);
-
-                var ds = new DataSet();
-
-                ds.ReadXml(xmlReader);
-
-                var dj = MKMHelpers.JoinDataTables(ds.Tables[0], dt,
+                var dj = MKMHelpers.JoinDataTables(articles, dt,
                     (row1, row2) => row1.Field<string>("idProduct") == row2.Field<string>("idProduct"));
 
                 dj = MKMHelpers.JoinDataTables(dj, eS,
@@ -85,7 +108,6 @@ namespace MKMTool
                 dj.Columns[dj.Columns.IndexOf("Name")].SetOrdinal(0);
 
                 stockGridView.DataSource = dj;
-                //dataGridView1.DataSource = dt;
             }
             catch (Exception eError)
             {

--- a/MKMTool/UpdatePriceSettings.Designer.cs
+++ b/MKMTool/UpdatePriceSettings.Designer.cs
@@ -74,6 +74,7 @@ namespace MKMTool
             this.labelMatchExplanation = new System.Windows.Forms.Label();
             this.radioButtonCondMatchOnly = new System.Windows.Forms.RadioButton();
             this.groupBoxPriceEstim = new System.Windows.Forms.GroupBox();
+            this.checkBoxPriceEstWorldwide = new System.Windows.Forms.CheckBox();
             this.textBoxPriceEstMaxDiff = new System.Windows.Forms.TextBox();
             this.panelPriceEstForSliderLabel = new System.Windows.Forms.Panel();
             this.labelPriceEstSliderValue = new System.Windows.Forms.Label();
@@ -126,7 +127,7 @@ namespace MKMTool
             this.groupBoxLogSettings.Controls.Add(this.checkBoxLogSmallChange);
             this.groupBoxLogSettings.Controls.Add(this.checkBoxLogMinItems);
             this.groupBoxLogSettings.Controls.Add(this.checkBoxLogUpdated);
-            this.groupBoxLogSettings.Location = new System.Drawing.Point(13, 331);
+            this.groupBoxLogSettings.Location = new System.Drawing.Point(13, 344);
             this.groupBoxLogSettings.Name = "groupBoxLogSettings";
             this.groupBoxLogSettings.Size = new System.Drawing.Size(788, 99);
             this.groupBoxLogSettings.TabIndex = 14;
@@ -199,7 +200,7 @@ namespace MKMTool
             this.groupBoxConditionSettings.Controls.Add(this.radioButtonCondAcceptBetterAlways);
             this.groupBoxConditionSettings.Controls.Add(this.labelMatchExplanation);
             this.groupBoxConditionSettings.Controls.Add(this.radioButtonCondMatchOnly);
-            this.groupBoxConditionSettings.Location = new System.Drawing.Point(13, 253);
+            this.groupBoxConditionSettings.Location = new System.Drawing.Point(13, 266);
             this.groupBoxConditionSettings.Name = "groupBoxConditionSettings";
             this.groupBoxConditionSettings.Size = new System.Drawing.Size(788, 72);
             this.groupBoxConditionSettings.TabIndex = 13;
@@ -251,6 +252,7 @@ namespace MKMTool
             // 
             // groupBoxPriceEstim
             // 
+            this.groupBoxPriceEstim.Controls.Add(this.checkBoxPriceEstWorldwide);
             this.groupBoxPriceEstim.Controls.Add(this.textBoxPriceEstMaxDiff);
             this.groupBoxPriceEstim.Controls.Add(this.panelPriceEstForSliderLabel);
             this.groupBoxPriceEstim.Controls.Add(this.trackBarPriceEstAvg);
@@ -273,14 +275,25 @@ namespace MKMTool
             this.groupBoxPriceEstim.Controls.Add(this.statusLabel);
             this.groupBoxPriceEstim.Location = new System.Drawing.Point(12, 12);
             this.groupBoxPriceEstim.Name = "groupBoxPriceEstim";
-            this.groupBoxPriceEstim.Size = new System.Drawing.Size(789, 235);
+            this.groupBoxPriceEstim.Size = new System.Drawing.Size(789, 248);
             this.groupBoxPriceEstim.TabIndex = 12;
             this.groupBoxPriceEstim.TabStop = false;
             this.groupBoxPriceEstim.Text = "Price estimation";
             // 
+            // checkBoxPriceEstWorldwide
+            // 
+            this.checkBoxPriceEstWorldwide.AutoSize = true;
+            this.checkBoxPriceEstWorldwide.Location = new System.Drawing.Point(11, 38);
+            this.checkBoxPriceEstWorldwide.Name = "checkBoxPriceEstWorldwide";
+            this.checkBoxPriceEstWorldwide.Size = new System.Drawing.Size(427, 17);
+            this.checkBoxPriceEstWorldwide.TabIndex = 50;
+            this.checkBoxPriceEstWorldwide.Text = "Ignore seller\'s country if minimum # of items is not found in my country (without" +
+    " culling)";
+            this.checkBoxPriceEstWorldwide.UseVisualStyleBackColor = true;
+            // 
             // textBoxPriceEstMaxDiff
             // 
-            this.textBoxPriceEstMaxDiff.Location = new System.Drawing.Point(254, 66);
+            this.textBoxPriceEstMaxDiff.Location = new System.Drawing.Point(256, 86);
             this.textBoxPriceEstMaxDiff.Name = "textBoxPriceEstMaxDiff";
             this.textBoxPriceEstMaxDiff.Size = new System.Drawing.Size(526, 20);
             this.textBoxPriceEstMaxDiff.TabIndex = 49;
@@ -290,7 +303,7 @@ namespace MKMTool
             // panelPriceEstForSliderLabel
             // 
             this.panelPriceEstForSliderLabel.Controls.Add(this.labelPriceEstSliderValue);
-            this.panelPriceEstForSliderLabel.Location = new System.Drawing.Point(254, 152);
+            this.panelPriceEstForSliderLabel.Location = new System.Drawing.Point(256, 169);
             this.panelPriceEstForSliderLabel.Name = "panelPriceEstForSliderLabel";
             this.panelPriceEstForSliderLabel.Size = new System.Drawing.Size(526, 23);
             this.panelPriceEstForSliderLabel.TabIndex = 37;
@@ -308,7 +321,7 @@ namespace MKMTool
             // 
             // trackBarPriceEstAvg
             // 
-            this.trackBarPriceEstAvg.Location = new System.Drawing.Point(256, 107);
+            this.trackBarPriceEstAvg.Location = new System.Drawing.Point(258, 124);
             this.trackBarPriceEstAvg.Maximum = 50;
             this.trackBarPriceEstAvg.Name = "trackBarPriceEstAvg";
             this.trackBarPriceEstAvg.Size = new System.Drawing.Size(526, 45);
@@ -319,7 +332,7 @@ namespace MKMTool
             // labelPriceEstMaximumPrice
             // 
             this.labelPriceEstMaximumPrice.AutoSize = true;
-            this.labelPriceEstMaximumPrice.Location = new System.Drawing.Point(6, 43);
+            this.labelPriceEstMaximumPrice.Location = new System.Drawing.Point(8, 63);
             this.labelPriceEstMaximumPrice.Name = "labelPriceEstMaximumPrice";
             this.labelPriceEstMaximumPrice.Size = new System.Drawing.Size(95, 13);
             this.labelPriceEstMaximumPrice.TabIndex = 17;
@@ -329,7 +342,7 @@ namespace MKMTool
             // 
             // textBoxPriceEstMaxChange
             // 
-            this.textBoxPriceEstMaxChange.Location = new System.Drawing.Point(254, 40);
+            this.textBoxPriceEstMaxChange.Location = new System.Drawing.Point(256, 60);
             this.textBoxPriceEstMaxChange.Name = "textBoxPriceEstMaxChange";
             this.textBoxPriceEstMaxChange.Size = new System.Drawing.Size(526, 20);
             this.textBoxPriceEstMaxChange.TabIndex = 18;
@@ -339,7 +352,7 @@ namespace MKMTool
             // labelPriceEstAvgOutliers1
             // 
             this.labelPriceEstAvgOutliers1.AutoSize = true;
-            this.labelPriceEstAvgOutliers1.Location = new System.Drawing.Point(6, 69);
+            this.labelPriceEstAvgOutliers1.Location = new System.Drawing.Point(8, 89);
             this.labelPriceEstAvgOutliers1.Name = "labelPriceEstAvgOutliers1";
             this.labelPriceEstAvgOutliers1.Size = new System.Drawing.Size(217, 13);
             this.labelPriceEstAvgOutliers1.TabIndex = 48;
@@ -350,7 +363,7 @@ namespace MKMTool
             // labelPriceEstHighestPrice
             // 
             this.labelPriceEstHighestPrice.AutoSize = true;
-            this.labelPriceEstHighestPrice.Location = new System.Drawing.Point(330, 210);
+            this.labelPriceEstHighestPrice.Location = new System.Drawing.Point(332, 227);
             this.labelPriceEstHighestPrice.Name = "labelPriceEstHighestPrice";
             this.labelPriceEstHighestPrice.Size = new System.Drawing.Size(325, 13);
             this.labelPriceEstHighestPrice.TabIndex = 32;
@@ -360,7 +373,7 @@ namespace MKMTool
             // 
             this.numericUpDownPriceEstHighestPrice.DecimalPlaces = 2;
             this.numericUpDownPriceEstHighestPrice.Enabled = false;
-            this.numericUpDownPriceEstHighestPrice.Location = new System.Drawing.Point(254, 208);
+            this.numericUpDownPriceEstHighestPrice.Location = new System.Drawing.Point(256, 225);
             this.numericUpDownPriceEstHighestPrice.Maximum = new decimal(new int[] {
             10000,
             0,
@@ -379,7 +392,7 @@ namespace MKMTool
             // radioButtonPriceEstHighestPrice
             // 
             this.radioButtonPriceEstHighestPrice.AutoSize = true;
-            this.radioButtonPriceEstHighestPrice.Location = new System.Drawing.Point(9, 208);
+            this.radioButtonPriceEstHighestPrice.Location = new System.Drawing.Point(11, 225);
             this.radioButtonPriceEstHighestPrice.Name = "radioButtonPriceEstHighestPrice";
             this.radioButtonPriceEstHighestPrice.Size = new System.Drawing.Size(180, 17);
             this.radioButtonPriceEstHighestPrice.TabIndex = 30;
@@ -391,7 +404,7 @@ namespace MKMTool
             // labelPriceEstLowestPrice
             // 
             this.labelPriceEstLowestPrice.AutoSize = true;
-            this.labelPriceEstLowestPrice.Location = new System.Drawing.Point(330, 180);
+            this.labelPriceEstLowestPrice.Location = new System.Drawing.Point(332, 197);
             this.labelPriceEstLowestPrice.Name = "labelPriceEstLowestPrice";
             this.labelPriceEstLowestPrice.Size = new System.Drawing.Size(408, 13);
             this.labelPriceEstLowestPrice.TabIndex = 29;
@@ -402,7 +415,7 @@ namespace MKMTool
             // 
             this.numericUpDownPriceEstLowestPrice.DecimalPlaces = 2;
             this.numericUpDownPriceEstLowestPrice.Enabled = false;
-            this.numericUpDownPriceEstLowestPrice.Location = new System.Drawing.Point(254, 178);
+            this.numericUpDownPriceEstLowestPrice.Location = new System.Drawing.Point(256, 195);
             this.numericUpDownPriceEstLowestPrice.Maximum = new decimal(new int[] {
             10000,
             0,
@@ -421,7 +434,7 @@ namespace MKMTool
             // radioButtonPriceEstByLowestPrice
             // 
             this.radioButtonPriceEstByLowestPrice.AutoSize = true;
-            this.radioButtonPriceEstByLowestPrice.Location = new System.Drawing.Point(9, 178);
+            this.radioButtonPriceEstByLowestPrice.Location = new System.Drawing.Point(11, 195);
             this.radioButtonPriceEstByLowestPrice.Name = "radioButtonPriceEstByLowestPrice";
             this.radioButtonPriceEstByLowestPrice.Size = new System.Drawing.Size(176, 17);
             this.radioButtonPriceEstByLowestPrice.TabIndex = 26;
@@ -434,7 +447,7 @@ namespace MKMTool
             // 
             this.radioButtonPriceEstPriceByAvg.AutoSize = true;
             this.radioButtonPriceEstPriceByAvg.Checked = true;
-            this.radioButtonPriceEstPriceByAvg.Location = new System.Drawing.Point(9, 109);
+            this.radioButtonPriceEstPriceByAvg.Location = new System.Drawing.Point(11, 126);
             this.radioButtonPriceEstPriceByAvg.Name = "radioButtonPriceEstPriceByAvg";
             this.radioButtonPriceEstPriceByAvg.Size = new System.Drawing.Size(159, 17);
             this.radioButtonPriceEstPriceByAvg.TabIndex = 25;
@@ -532,7 +545,7 @@ namespace MKMTool
             // labelPriceEstMinPrice
             // 
             this.labelPriceEstMinPrice.AutoSize = true;
-            this.labelPriceEstMinPrice.Location = new System.Drawing.Point(6, 16);
+            this.labelPriceEstMinPrice.Location = new System.Drawing.Point(8, 16);
             this.labelPriceEstMinPrice.Name = "labelPriceEstMinPrice";
             this.labelPriceEstMinPrice.Size = new System.Drawing.Size(147, 13);
             this.labelPriceEstMinPrice.TabIndex = 15;
@@ -559,7 +572,7 @@ namespace MKMTool
             // checkBoxTestMode
             // 
             this.checkBoxTestMode.AutoSize = true;
-            this.checkBoxTestMode.Location = new System.Drawing.Point(23, 541);
+            this.checkBoxTestMode.Location = new System.Drawing.Point(23, 554);
             this.checkBoxTestMode.Name = "checkBoxTestMode";
             this.checkBoxTestMode.Size = new System.Drawing.Size(248, 17);
             this.checkBoxTestMode.TabIndex = 15;
@@ -573,7 +586,7 @@ namespace MKMTool
             this.groupBoxPresets.Controls.Add(this.buttonPresetsStore);
             this.groupBoxPresets.Controls.Add(this.buttonPresetsLoad);
             this.groupBoxPresets.Controls.Add(this.comboBoxPresets);
-            this.groupBoxPresets.Location = new System.Drawing.Point(13, 436);
+            this.groupBoxPresets.Location = new System.Drawing.Point(13, 449);
             this.groupBoxPresets.Name = "groupBoxPresets";
             this.groupBoxPresets.Size = new System.Drawing.Size(787, 99);
             this.groupBoxPresets.TabIndex = 16;
@@ -655,7 +668,7 @@ namespace MKMTool
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(812, 570);
+            this.ClientSize = new System.Drawing.Size(812, 578);
             this.Controls.Add(this.groupBoxPresets);
             this.Controls.Add(this.checkBoxTestMode);
             this.Controls.Add(this.groupBoxLogSettings);
@@ -729,5 +742,6 @@ namespace MKMTool
         private System.Windows.Forms.ToolTip toolTipMaxPriceChange;
         private System.Windows.Forms.ToolTip toolTipMaxDifference;
         private System.Windows.Forms.Label labelPresetsDescr;
+        private System.Windows.Forms.CheckBox checkBoxPriceEstWorldwide;
     }
 }

--- a/MKMTool/UpdatePriceSettings.cs
+++ b/MKMTool/UpdatePriceSettings.cs
@@ -147,6 +147,7 @@ namespace MKMTool
             s.logHighPriceVariance = checkBoxLogHighVariance.Checked;
             
             s.testMode = checkBoxTestMode.Checked;
+            s.searchWorldwide = checkBoxPriceEstWorldwide.Checked;
 
             return true;
         }
@@ -224,6 +225,7 @@ namespace MKMTool
             checkBoxLogHighVariance.Checked = settings.logHighPriceVariance;
 
             checkBoxTestMode.Checked = settings.testMode;
+            checkBoxPriceEstWorldwide.Checked = settings.searchWorldwide;
         }
                 
         private void checkBoxCondMatchOnly_CheckedChanged(object sender, EventArgs e)

--- a/MKMTool/UpdatePriceSettings.resx
+++ b/MKMTool/UpdatePriceSettings.resx
@@ -123,6 +123,9 @@
   <metadata name="toolTipMaxPriceChange.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>16, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>45</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/MKMTool/WantlistEditorView.cs
+++ b/MKMTool/WantlistEditorView.cs
@@ -288,7 +288,7 @@ namespace MKMTool
                 {
                     var sListId = (wantListsBox.SelectedItem as MKMHelpers.ComboboxItem).Value.ToString();
 
-                    MKMInteract.RequestHelper.makeRequest("https://www.mkmapi.eu/ws/v2.0/wantslist/" + sListId, "PUT",
+                    MKMInteract.RequestHelper.makeRequest("https://api.cardmarket.com/ws/v2.0/wantslist/" + sListId, "PUT",
                         sRequestXML);
 
                     //MessageBox.Show("Item " + idProduct + " added successfully!");
@@ -325,7 +325,7 @@ namespace MKMTool
 
                 var sListId = (wantListsBox.SelectedItem as MKMHelpers.ComboboxItem).Value.ToString();
 
-                MKMInteract.RequestHelper.makeRequest("https://www.mkmapi.eu/ws/v2.0/wantslist/" + sListId, "PUT",
+                MKMInteract.RequestHelper.makeRequest("https://api.cardmarket.com/ws/v2.0/wantslist/" + sListId, "PUT",
                     sRequestXML);
 
                 wantsListBoxReload();

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Welcome to MKMTool 0.6
+# Welcome to MKMTool 0.6.1
 
 ## Last changes
+
+x.3.2018
++ Mint condition is treated as Near Mint when looking for similar items
 
 27.01.2018 (by Tomas Janak)
 + Added customizable settings for Update Price (see documentation below)
 + Price update no longer uses your own items when calculating the price
-+ Prices are not updated if their would change only little (limit is customizable)
 + Richer log options
 
 11.07.2017

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 ## Last changes
 
-x.3.2018
+9.2.2019 (by Tomas Janak)
 + Mint condition is treated as Near Mint when looking for similar items
 + Added an option to search for similar items worldwide (ignoring your country) if there aren't enough similar items in your country
 + Fixed a bug causing in some cases the last added item to not be considered as matching condition even when it was
 + Comments are no longer removed from the article upon update
++ Added a "check for cheap deals from user" option
 
 27.01.2018 (by Tomas Janak)
 + Added customizable settings for Update Price (see documentation below)
@@ -124,9 +125,11 @@ You must feel comfortable with the formula or change it to your demands, be awar
 
 ![screenshot](http://www.alexander-pick.com/github/tool2.PNG)
 
-For the fun of it – with this feature you can find cheap deals with X percent cheaper than other vendors and cheaper than the Trend if selected.- The algo calcs + 1 Eur fixed for shipping to score you a good deal with resale value. It’s also possible to check for cheap deals of cards on your wants list, use this if you are only looking for specific cards. Beware, this feature is API call heavy.
+For the fun of it – with this feature you can find cheap deals with X percent cheaper than other vendors and cheaper than the Trend if selected. The algo calcs + 1 Eur fixed for shipping to score you a good deal with resale value. It’s also possible to check for cheap deals of cards on your wants list, use this if you are only looking for specific cards. Beware, this feature is API call heavy.
 
 If cards are found they are directly added to your cart on MKM, just log in and check your cart.
+
+You can also specify to look for cheap deals from a given user - check the "User" checkbox and then fill in the username. The same algorithm will be used, but only on stock of that user.
 
 ### Check Display Value
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Last changes
 
 9.2.2019 (by Tomas Janak)
++ Fixed "Bad Request 400" error when working with more than 100 items (partially by Ramiro Aparicio) after API changes announced on 6.2.2019
 + Mint condition is treated as Near Mint when looking for similar items
 + Added an option to search for similar items worldwide (ignoring your country) if there aren't enough similar items in your country
 + Fixed a bug causing in some cases the last added item to not be considered as matching condition even when it was
@@ -15,7 +16,7 @@
 + Richer log options
 
 11.07.2017
-+ Fixed weird ug which caused wrong price calculation on foregin systems
++ Fixed weird bug which caused wrong price calculation on foreign systems
 + Fixed crash if articles other than singles are listed on the account
 
 24.04.2017
@@ -26,7 +27,7 @@
 + changed the default minutes for the bot
 
 23.02.2017
-+ country is no longer hardcoded and now determained at startup from your account details
++ country is no longer hard-coded and now determined at startup from your account details
 + code was cleaned up
 
 22.02.2017

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 x.3.2018
 + Mint condition is treated as Near Mint when looking for similar items
++ Added an option to search for similar items worldwide (ignoring your country) if there aren't enough similar items in your country
++ Fixed a bug causing in some cases the last added item to not be considered as matching condition even when it was
 
 27.01.2018 (by Tomas Janak)
 + Added customizable settings for Update Price (see documentation below)
@@ -84,6 +86,7 @@ The following figure shows the settings window. Each of the parameters will now 
 + **Minimum price of rares:** This is the minimum price that will ever be assigned to your rares (and mythics) no matter what price is computed.
 + **Minimum # of similar items:** if by the end the sequence of similar items is smaller than this number, no price update will be performed.
 + **Maximum # of similar items:** once the sequence of similar items has this many items, the algorithm will stop adding new ones and will move on to computing the price. Since the sequence is built from cheapest to most expensive items, the larger this number is, the higher the computed price will potentially be as more expensive items will be included. However, it also limits the possibility of the price being too low due to some outliers.
++ **Ignore seller's country:** when checked and the minimum # of similar items is not found among seller's from your country, the items are processed again, this time ignoring the country of the seller. This is done only if there is not enough similar items without any culling - if the minimum is not reached because of culling, this will not be done. This option ensures that your prices are updated even for items that nobody in your country sells - typically rare cards like foreign foils etc.
 + **Max price change:** this allows you to set limits to how much can MKMTool change the prices of your cards. If the computed price is too much lower or higher than current price, it will not be sent to MKM. To account for different limits for different prices, this parameter is set as a sequence of pairs of numbers "T1;C1;T2;C2;T3;C3" etc. The first number in each pair, Tx, is a price threshold in €, the second number, Cx, is maximal allowed change in % of current price. For example, on the screenshot above you can see the following sequence: "1;200;5;25;10;15;50;10;100;5;999999;3;".
     
 	This means: cards cheaper than 1€ can change by at most 200%, cards cheaper than 5€ by 25%, below 10€ by 15% etc. Let's say you have listed a card A for 0.5€ and card B for 11€. MKMTool will compute new price for card A as 1.4€. This is a 180% change, but that is ok, the price for this level can change by 200%, so anything between 0€ and 1.50€ for card A is good. For price B, it computes 9.35€, i.e. a 15% decrease. Original price is 11€, hence it belongs to the "50;10" pair, i.e. max allowed change 10%. This would be violated, so card B will remain at 11€.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ x.3.2018
 + Mint condition is treated as Near Mint when looking for similar items
 + Added an option to search for similar items worldwide (ignoring your country) if there aren't enough similar items in your country
 + Fixed a bug causing in some cases the last added item to not be considered as matching condition even when it was
++ Comments are no longer removed from the article upon update
 
 27.01.2018 (by Tomas Janak)
 + Added customizable settings for Update Price (see documentation below)


### PR DESCRIPTION
- Several small bugfixes to price updates
- Since February 2019, due to some API changes all stock-handling request must work with at most 100 items - this modifies price update of MKMTool to respect that
- The pull request #7 by friscoMad is already merged into this one - it was easier to do it this way since the merge was rather complicated with the bugfixes I made
- Some small new features: option to use non-domestic prices during price update if there are not enough domestic ones; "look for cheap deals" can now be limited to a particular seller